### PR TITLE
Implements an instance toString() method on JSONObject.

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/json/JSONObject.java
+++ b/jOOQ/src/main/java/org/jooq/tools/json/JSONObject.java
@@ -123,6 +123,10 @@ public class JSONObject extends HashMap{
         return sb.toString();
     }
 
+    @Override public String toString() {
+        return toJSONString(this);
+    }
+
     /**
      * Escape quotes, \, /, \r, \n, \b, \f, \t and other control characters
      * (U+0000 through U+001F). It's the same as JSONValue.escape() only for

--- a/jOOQ/src/test/java/org/jooq/tools/JSONObjectTest.java
+++ b/jOOQ/src/test/java/org/jooq/tools/JSONObjectTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2009-2015, Data Geekery GmbH (http://www.datageekery.com)
+ * All rights reserved.
+ *
+ * This work is dual-licensed
+ * - under the Apache Software License 2.0 (the "ASL")
+ * - under the jOOQ License and Maintenance Agreement (the "jOOQ License")
+ * =============================================================================
+ * You may choose which license applies to you:
+ *
+ * - If you're using this work with Open Source databases, you may choose
+ *   either ASL or jOOQ License.
+ * - If you're using this work with at least one commercial database, you must
+ *   choose jOOQ License
+ *
+ * For more information, please visit http://www.jooq.org/licenses
+ *
+ * Apache Software License 2.0:
+ * -----------------------------------------------------------------------------
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * jOOQ License and Maintenance Agreement:
+ * -----------------------------------------------------------------------------
+ * Data Geekery grants the Customer the non-exclusive, timely limited and
+ * non-transferable license to install and use the Software under the terms of
+ * the jOOQ License and Maintenance Agreement.
+ *
+ * This library is distributed with a LIMITED WARRANTY. See the jOOQ License
+ * and Maintenance Agreement for more details: http://www.jooq.org/licensing
+ */
+package org.jooq.tools;
+
+import java.util.HashMap;
+import org.jooq.tools.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alok Menghrajani
+ */
+public class JSONObjectTest {
+
+    @Test
+    public void testJSONObjectToString() {
+        HashMap<String, String> map = new HashMap<String, String>();
+
+        map.put("foo", "bar");
+        assertEquals(new JSONObject(map).toString(), "{\"foo\":\"bar\"}");
+        assertEquals(JSONObject.toJSONString(map), "{\"foo\":\"bar\"}");
+
+        map.put("jOOQ", "isfun!");
+        String s = new JSONObject(map).toString();
+        assertTrue(s.equals("{\"foo\":\"bar\",\"jOOQ\":\"isfun!\"}") ||
+            s.equals("{\"jOOQ\":\"isfun!\",\"foo\":\"bar\"}"));
+
+        s = JSONObject.toJSONString(map);
+        assertTrue(s.equals("{\"foo\":\"bar\",\"jOOQ\":\"isfun!\"}") ||
+            s.equals("{\"jOOQ\":\"isfun!\",\"foo\":\"bar\"}"));
+    }
+}


### PR DESCRIPTION
http://www.jooq.org/javadoc/latest/ is not very clear about JSONObject
taking a map as a parameter in the constructor but calling toString on
the resulting object won't return a JSON string.

I feel things can be improved by either adding something to the documentation
or by having a toString() method which calls toJSONString. This commit
implements the latter.

If this change makes sense we can do the same thing for JSONArray and JSONValue.
